### PR TITLE
fix: 云函数异常响应时，http status 设置有误

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,15 @@
 			<version>${jettyVersion}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-client</artifactId>
+			<version>${jettyVersion}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
-		<plugins>			
+		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/cn/leancloud/LeanEngine.java
+++ b/src/main/java/cn/leancloud/LeanEngine.java
@@ -12,8 +12,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import cn.leancloud.EndpointParser.EndpointInfo;
-
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.serializer.SerializerFeature;
@@ -26,9 +24,12 @@ import com.avos.avoscloud.internal.InternalConfigurationController;
 import com.avos.avoscloud.internal.MasterKeyConfiguration;
 import com.avos.avoscloud.internal.impl.EnginePersistenceImplementation;
 
+import cn.leancloud.EndpointParser.EndpointInfo;
 
-@WebServlet(name = "LeanEngineServlet", urlPatterns = {"/1/functions/*", "/1.1/functions/*",
-    "/1/call/*", "/1.1/call/*"}, loadOnStartup = 0)
+
+@WebServlet(name = "LeanEngineServlet",
+    urlPatterns = {"/1/functions/*", "/1.1/functions/*", "/1/call/*", "/1.1/call/*"},
+    loadOnStartup = 0)
 public class LeanEngine extends HttpServlet {
 
   public static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
@@ -38,8 +39,8 @@ public class LeanEngine extends HttpServlet {
 
   private static Map<String, EngineHandlerInfo> funcs = new HashMap<String, EngineHandlerInfo>();
   static {
-    InternalConfigurationController.globalInstance().setInternalPersistence(
-        EnginePersistenceImplementation.instance());
+    InternalConfigurationController.globalInstance()
+        .setInternalPersistence(EnginePersistenceImplementation.instance());
   }
 
   private static EngineSessionCookie sessionCookie;
@@ -128,8 +129,7 @@ public class LeanEngine extends HttpServlet {
     setAllowOriginHeader(req, resp);
     resp.setHeader("Access-Control-Max-Age", "86400");
     resp.setHeader("Access-Control-Allow-Methods", "PUT, GET, POST, DELETE, OPTIONS");
-    resp.setHeader(
-        "Access-Control-Allow-Headers",
+    resp.setHeader("Access-Control-Allow-Headers",
         "X-LC-Id, X-LC-Key, X-LC-Session, X-LC-Sign, X-LC-Prod, X-LC-UA, X-Uluru-Application-Key, X-Uluru-Application-Id, X-Uluru-Application-Production, X-Uluru-Client-Version, X-Uluru-Session-Token, X-AVOSCloud-Application-Key, X-AVOSCloud-Application-Id, X-AVOSCloud-Application-Production, X-AVOSCloud-Client-Version, X-AVOSCloud-Session-Token, X-AVOSCloud-Super-Key, X-Requested-With, Content-Type, X-AVOSCloud-Request-sign");
     resp.setHeader("Content-Length", "0");
     resp.setStatus(HttpServletResponse.SC_OK);
@@ -137,8 +137,8 @@ public class LeanEngine extends HttpServlet {
   }
 
   @Override
-  protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException,
-      IOException {
+  protected void doPost(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
     setAllowOriginHeader(req, resp);
     try {
       RequestAuth.auth(req);
@@ -174,11 +174,13 @@ public class LeanEngine extends HttpServlet {
         if (internalEndpoint.isNeedResponse()) {
           resp.setContentType(JSON_CONTENT_TYPE);
           JSONObject result = new JSONObject();
-          result.put("code",
-              e.getCause() instanceof AVException ? ((AVException) e.getCause()).getCode() : 1);
+          result.put("code", 1);
           result.put("error", e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
+          resp.setStatus(e.getCause() instanceof AVException
+              ? ((AVException) e.getCause()).getCode() : HttpServletResponse.SC_BAD_REQUEST);
           resp.getWriter().write(result.toJSONString());
         }
+        // TODO 区别服务端异常和客户端异常，客户端异常没必要输出异常堆栈，否则日志太容易爆
         if (e.getCause() != null) {
           e.getCause().printStackTrace();
         } else {

--- a/src/test/java/cn/leancloud/leanengine_test/AllEngineHook.java
+++ b/src/test/java/cn/leancloud/leanengine_test/AllEngineHook.java
@@ -2,28 +2,16 @@ package cn.leancloud.leanengine_test;
 
 import java.util.List;
 
-import cn.leancloud.EngineHook;
-import cn.leancloud.EngineHookType;
-import cn.leancloud.EngineRequestContext;
-
 import com.avos.avoscloud.AVException;
 import com.avos.avoscloud.AVObject;
 import com.avos.avoscloud.AVUser;
 import com.avos.avoscloud.AVUtils;
 
-public class AllEngineHook {
+import cn.leancloud.EngineHook;
+import cn.leancloud.EngineHookType;
+import cn.leancloud.EngineRequestContext;
 
-  @EngineHook(className = "hello", type = EngineHookType.beforeSave)
-  public static AVObject beforeSave(AVObject obj) throws Exception {
-    if (obj.getInt("star") <= 50) {
-      if (obj.getInt("star") > 30) {
-        obj.put("star", 30);
-      }
-      return obj;
-    } else {
-      throw new AVException(400, "star should less than 50");
-    }
-  }
+public class AllEngineHook {
 
   @EngineHook(className = "_User", type = EngineHookType.onLogin)
   public static void testOnLogin(AVUser user) throws Exception {
@@ -38,6 +26,19 @@ public class AllEngineHook {
   public static void testSMSVerified(AVUser user) throws Exception {
     if (!"576ccfbbd342d30057b6e5af".equals(user.getObjectId())) {
       throw new AVException(400, "wrong user");
+    }
+  }
+
+  @EngineHook(className = "TestReview", type = EngineHookType.beforeSave)
+  public static AVObject beforeSave(AVObject obj) throws Exception {
+    if (obj.getInt("star") <= 50) {
+      if (obj.getInt("star") > 30) {
+        obj.put("star", 30);
+      }
+      return obj;
+    } else {
+      // TODO 不建议让用户设置 400 这样的响应码，希望能隐藏 http 的细节。
+      throw new AVException(400, "star should less than 50");
     }
   }
 

--- a/src/test/java/cn/leancloud/leanengine_test/EngineBasicTest.java
+++ b/src/test/java/cn/leancloud/leanengine_test/EngineBasicTest.java
@@ -9,14 +9,14 @@ import org.eclipse.jetty.servlet.ServletHandler;
 import org.junit.After;
 import org.junit.Before;
 
+import com.avos.avoscloud.AVOSCloud;
+import com.avos.avoscloud.internal.impl.EngineRequestSign;
+import com.avos.avoscloud.okhttp.Request;
+
 import cn.leancloud.EngineSessionCookie;
 import cn.leancloud.HttpsRequestRedirectFilter;
 import cn.leancloud.LeanEngine;
 import cn.leancloud.RequestUserAuthFilter;
-
-import com.avos.avoscloud.AVOSCloud;
-import com.avos.avoscloud.internal.impl.EngineRequestSign;
-import com.avos.avoscloud.okhttp.Request;
 
 public class EngineBasicTest {
 
@@ -56,11 +56,27 @@ public class EngineBasicTest {
 
   public Request.Builder getBasicTestRequestBuilder() {
     Request.Builder builder = new Request.Builder();
-    builder.addHeader("X-LC-Id", "uu2P5gNTxGhjyaJGAPPnjCtJ-gzGzoHsz");
-    builder.addHeader("X-LC-Key", "j5lErUd6q7LhPD8CXhfmA2Rg");
-    builder.addHeader("x-uluru-master-key", "atXAmIVlQoBDBLqumMgzXhcY");
-    builder.addHeader("Content-Type", "application/json");
+    builder.addHeader("X-LC-Id", getAppId());
+    builder.addHeader("X-LC-Key", getAppKey());
+    builder.addHeader("x-uluru-master-key", getMasterKey());
+    builder.addHeader("Content-Type", getContentType());
     return builder;
+  }
+
+  protected String getAppId() {
+    return "uu2P5gNTxGhjyaJGAPPnjCtJ-gzGzoHsz";
+  }
+
+  protected String getAppKey() {
+    return "j5lErUd6q7LhPD8CXhfmA2Rg";
+  }
+
+  protected String getMasterKey() {
+    return "atXAmIVlQoBDBLqumMgzXhcY";
+  }
+
+  protected String getContentType() {
+    return "application/json";
   }
 
 }

--- a/src/test/java/cn/leancloud/leanengine_test/EngineHookTest2.java
+++ b/src/test/java/cn/leancloud/leanengine_test/EngineHookTest2.java
@@ -1,0 +1,44 @@
+package cn.leancloud.leanengine_test;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.util.StringContentProvider;
+import org.junit.Test;
+
+import cn.leancloud.LeanEngine;
+
+public class EngineHookTest2 extends EngineBasicTest {
+
+  private HttpClient httpClient;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    LeanEngine.register(AllEngineHook.class);
+    httpClient = new HttpClient();
+    httpClient.start();
+  }
+
+
+  public void teardown() throws Exception {
+    super.teardown();
+    httpClient.stop();
+  }
+
+  @Test
+  public void testHookWithError() throws Exception {
+    String content = "{\"object\":{\"star\":100}}";
+    ContentResponse response =
+        httpClient.POST("http://localhost:3000/1.1/functions/TestReview/beforeSave")
+            .header("x-lc-id", getAppId()).header("x-lc-key", getAppKey())
+            .content(new StringContentProvider(content), getContentType()).send();
+    assertEquals(HttpServletResponse.SC_BAD_REQUEST, response.getStatus());
+    assertEquals("{\"code\":1,\"error\":\"star should less than 50\"}",
+        response.getContentAsString());
+  }
+
+}


### PR DESCRIPTION
异常响应时，http status 一般为 400，因为存储服务基本只关心 200 或者 400的响应码。body 中的 code 一般总是 1。

增加了 httpClient 的单元测试，方便确认 http 请求的细节。