### PR TITLE
return null when cannot access the value

### DIFF
--- a/src/main/java/cn/leancloud/EngineFunctionHandlerInfo.java
+++ b/src/main/java/cn/leancloud/EngineFunctionHandlerInfo.java
@@ -18,35 +18,21 @@ public class EngineFunctionHandlerInfo extends EngineHandlerInfo {
     if (methodParameterList.size() == 0) {
       return null;
     } else {
-      Object[] params;
       try {
         Map jsonParams = JSON.parseObject(requestBody, Map.class);
-        params = new Object[methodParameterList.size()];
+        Object[] params = new Object[methodParameterList.size()];
         for (int index = 0; index < methodParameterList.size(); index++) {
           Object p = jsonParams.get(methodParameterList.get(index).name);
           if (p == null) {
-            throw new InvalidParameterException();
+            params[index] = null;
+          } else {
+            params[index] = methodParameterList.get(index).parseParams(JSON.toJSONString(p));
           }
-          params[index] = methodParameterList.get(index).parseParams(JSON.toJSONString(p));
         }
+        return params;
       } catch (Exception e) {
-        if (methodParameterList.size() == 1) {
-          // when
-          Object param = null;
-          try {
-            EngineFunctionParamInfo paramInfo = methodParameterList.get(0);
-            param = paramInfo.parseParams(requestBody);
-            // 这里是假设唯一的目标作为参数传递过来，而不是放在一个jsonObject中间
-            return param;
-          } catch (Exception e1) {
-            throw new InvalidParameterException();
-            // 如果解析出错了，就认为传递过来的是一个jsonObject可以按照多于1个参数的情况来解析
-          }
-        } else {
-          throw new InvalidParameterException();
-        }
+        throw new InvalidParameterException();
       }
-      return params;
     }
   }
 }

--- a/src/main/java/cn/leancloud/EngineHandlerInfo.java
+++ b/src/main/java/cn/leancloud/EngineHandlerInfo.java
@@ -94,15 +94,16 @@ public abstract class EngineHandlerInfo {
     List<EngineFunctionParamInfo> params = new LinkedList<EngineFunctionParamInfo>();
     Annotation[][] annotationMatrix = method.getParameterAnnotations();
     Class<?>[] paramTypesArray = method.getParameterTypes();
-    if (annotationMatrix.length != paramTypesArray.length) {
-      LogUtil.avlog.e("Parameters not annotated correctly for EngineFunction:" + functionName);
-    }
     for (int index = 0; index < paramTypesArray.length; index++) {
       Annotation[] array = annotationMatrix[index];
-      for (Annotation an : array) {
-        if (an instanceof EngineFunctionParam) {
-          params.add(new EngineFunctionParamInfo(paramTypesArray[index], ((EngineFunctionParam) an)
-              .value()));
+      if (array.length == 0) {
+        LogUtil.avlog.e("Parameters not annotated correctly for EngineFunction:" + functionName);
+      } else {
+        for (Annotation an : array) {
+          if (an instanceof EngineFunctionParam) {
+            params.add(new EngineFunctionParamInfo(paramTypesArray[index], ((EngineFunctionParam) an)
+                    .value()));
+          }
         }
       }
     }

--- a/src/test/java/cn/leancloud/leanengine_test/AllEngineFunctions.java
+++ b/src/test/java/cn/leancloud/leanengine_test/AllEngineFunctions.java
@@ -20,7 +20,11 @@ public class AllEngineFunctions {
 
   @EngineFunction
   public static String hello(@EngineFunctionParam("name") String name) {
-    return "hello " + name;
+    if (null != name) {
+      return "hello " + name;
+    } else {
+      return "hello";
+    }
   }
 
   @EngineFunction("ping")

--- a/src/test/java/cn/leancloud/leanengine_test/FunctionTest.java
+++ b/src/test/java/cn/leancloud/leanengine_test/FunctionTest.java
@@ -70,6 +70,14 @@ public class FunctionTest extends EngineBasicTest {
   }
 
   @Test
+  public void testHelloWithWrongParam() throws  Exception {
+    Map<String, Object> params = new HashMap<String, Object>();
+    params.put("name1ss", "张三");
+    Object result = AVCloud.callFunction("hello", params);
+    assertEquals("hello", result);
+  }
+
+  @Test
   public void testAVCloudFunction() throws Exception {
     Map<String, Object> params = new HashMap<String, Object>();
     params.put("ts", 123);
@@ -84,22 +92,28 @@ public class FunctionTest extends EngineBasicTest {
     registerUser.setUsername(AVUtils.getRandomString(10) + System.currentTimeMillis());
     registerUser.setPassword(AVUtils.getRandomString(10));
     registerUser.signUp();
-    AVUser u = AVCloud.rpcFunction("ping", 123);
+
+    Map<String, Object> params = new HashMap<String, Object>();
+    params.put("ts", 123);
+    AVUser u = AVCloud.rpcFunction("ping", params);
     assertEquals(registerUser.getObjectId(), (u.getObjectId()));
   }
 
   @Test
   public void testSimpleObject() throws Exception {
+    Map<String, AVObject> rpcTestMap = new HashMap<String, AVObject>();
+
     AVObject obj = new AVObject("rpcTest");
     obj.put("int", 12);
     obj.save();
+    rpcTestMap.put("obj", obj);
 
-    String result = AVCloud.rpcFunction("simpleObject", obj);
+    String result = AVCloud.rpcFunction("simpleObject", rpcTestMap);
     assertEquals("success", result);
 
     obj.put("int", 3000);
     obj.save();
-    result = AVCloud.rpcFunction("simpleObject", obj);
+    result = AVCloud.rpcFunction("simpleObject", rpcTestMap);
     assertEquals("failure", result);
   }
 


### PR DESCRIPTION
主要修复了两个地方：
1、当云函数没有在 param 上添加 annotation 是输出错误日志的判断有问题，annotationMatrix 是一个二维数组，annotationMatrix.length 与 paramTypesArray.lentgh 恒等。
2、无论一个还是多个参数时，当没有找到对应的 annotation 时，直接返回 null。避免返回 exception 影响其他参数。

另外，这里其实是一个 breaking change，因为就像 testcase 中 testSimpleObject 这个一样，如果用户也使用了这个方式，会引起问题。
“如果参数不做注解，并且传入的是一个 Map，则直接将 json 参数转化成 map 传过去”，反射的时候是根据注解来的，如果没有注解，这个时候会直接抛出异常，所以这种情况也没有必要支持了。

@sdjcw 