### PR TITLE
feat: request context 增加 sessionToken 参数

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>cn.leancloud</groupId>
   <artifactId>leanengine</artifactId>
-  <version>0.2.6-SNAPSHOT</version>
+  <version>0.3.0-SNAPSHOT</version>
 
   <name>leancloud leanengine library</name>
   <description>leancloud leanengine library</description>

--- a/src/main/java/cn/leancloud/EngineRequestContext.java
+++ b/src/main/java/cn/leancloud/EngineRequestContext.java
@@ -15,10 +15,12 @@ public class EngineRequestContext {
 
   private static final String UPDATED_KEYS = "_updatedKeys";
   private static final String REMOTE_ADDRESS = "_remoteAddress";
+  private static final String SESSION_TOKEN = "_sessionToken";
   private static final String BEFORE_KEYS = "__before";
   private static final String AFTER_KEYS = "__after";
   static ThreadLocal<Map<String, Object>> localMeta = new ThreadLocal<Map<String, Object>>();
 
+  @Deprecated
   public static Map<String, Object> getMeta() {
     return localMeta.get();
   }
@@ -29,11 +31,7 @@ public class EngineRequestContext {
    * @return 被更新的属性
    */
   public static List<String> getUpdateKeys() {
-    Map<String, Object> meta = getMeta();
-    if (meta != null && meta.containsKey(UPDATED_KEYS)) {
-      return (List) meta.get(UPDATED_KEYS);
-    }
-    return null;
+    return (List) get(UPDATED_KEYS);
   }
 
   /**
@@ -42,11 +40,7 @@ public class EngineRequestContext {
    * @return 发起请求的 IP 地址
    */
   public static String getRemoteAddress() {
-    Map<String, Object> meta = getMeta();
-    if (meta != null && meta.containsKey(REMOTE_ADDRESS)) {
-      return (String) meta.get(REMOTE_ADDRESS);
-    }
-    return null;
+    return (String) get(REMOTE_ADDRESS);
   }
 
   protected static void parseMetaData(Map<String, Object> objectProperties) {
@@ -77,17 +71,37 @@ public class EngineRequestContext {
   }
 
   protected static void setRemoteAddress(String ip) {
-    Map<String, Object> existingMeta = localMeta.get();
-    if (existingMeta != null) {
-      existingMeta.put(REMOTE_ADDRESS, ip);
-    } else {
-      Map<String, Object> meta = new HashMap<String, Object>();
-      meta.put(REMOTE_ADDRESS, ip);
-      localMeta.set(meta);
-    }
+    put(REMOTE_ADDRESS, ip);
+  }
+
+  public static void setSessionToken(String sessionToken) {
+    put(SESSION_TOKEN, sessionToken);
+  }
+
+  public static String getSessionToken() {
+    return (String) get(SESSION_TOKEN);
   }
 
   public static void clean() {
     localMeta.set(null);
   }
+
+
+  protected static void put(String key, Object value) {
+    Map<String, Object> meta = localMeta.get();
+    if (meta == null) {
+      meta = new HashMap<>();
+      localMeta.set(meta);
+    }
+    meta.put(key, value);
+  }
+
+  protected static Object get(String key) {
+    Map<String, Object> meta = localMeta.get();
+    if (meta != null && meta.containsKey(key)) {
+      return meta.get(key);
+    }
+    return null;
+  }
+
 }

--- a/src/main/java/cn/leancloud/RequestAuth.java
+++ b/src/main/java/cn/leancloud/RequestAuth.java
@@ -88,6 +88,7 @@ class RequestAuth {
       if (AVUtils.isBlankString(remoteAddress)) {
         remoteAddress = req.getRemoteAddr();
       }
+      EngineRequestContext.setSessionToken(sessionToken);
       EngineRequestContext.setRemoteAddress(remoteAddress);
     }
   }

--- a/src/test/java/cn/leancloud/leanengine_test/AllEngineFunctions.java
+++ b/src/test/java/cn/leancloud/leanengine_test/AllEngineFunctions.java
@@ -63,6 +63,19 @@ public class AllEngineFunctions {
     return result;
   }
 
+  @EngineFunction("currentUserInfo")
+  public static Map<String, Object> getCurrentUserInfo() {
+    Map<String, Object> result = new HashMap<>();
+    AVUser user = AVUser.getCurrentUser();
+    if (user == null) {
+      return result;
+    }
+    result.put("objectId", user.getObjectId());
+    result.put("username", user.getUsername());
+    result.put("sessionToken", user.getSessionToken());
+    return result;
+  }
+
   @EngineFunction("cookieTest")
   public static AVUser cookieTest() throws AVException {
     return AVUser.getCurrentUser();
@@ -71,6 +84,14 @@ public class AllEngineFunctions {
   @EngineFunction("remoteAddress")
   public static String remoteAddress() throws AVException {
     return EngineRequestContext.getRemoteAddress();
+  }
+
+  @EngineFunction("metadata")
+  public static Map<String, Object> getMetadata() {
+    Map<String, Object> result = new HashMap<>();
+    result.put("remoteAddress", EngineRequestContext.getRemoteAddress());
+    result.put("sessionToken", EngineRequestContext.getSessionToken());
+    return result;
   }
 
   @EngineFunction()


### PR DESCRIPTION
可以获取客户端传递的原始 sessionToken 值。

EngineRequestContext.getMeta() 标记为不推荐，将在 v0.4 移除。